### PR TITLE
[OCR Patch]中国共产党八届八中全会关于以彭德怀同志为首的反党集团的错误的决议[中国大跃进大饥荒数据库

### DIFF
--- a/[a3987adad1][CCRD-dayuejin].ts
+++ b/[a3987adad1][CCRD-dayuejin].ts
@@ -1,0 +1,4 @@
+
+export default [
+  {"version":2,"parts":{"4":{"diff":"=115\t+%E4%B9%89\t=715"}},"comments":{},"description":""},
+];


### PR DESCRIPTION
close https://github.com/banned-historical-archives/banned-historical-archives.github.io/issues/3902